### PR TITLE
Change protocol for link to survey from http to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ We are not currently accepting applications, but we may do so in the future.
 ## Public resources
 
 - Best practices: [Open Source Guides](https://opensource.guide)
-- OSS data for research: [Open Source Survey](http://opensourcesurvey.org/2017/)
+- OSS data for research: [Open Source Survey](https://opensourcesurvey.org/2017/)
 - To help you get started as a contributor and convince your employers to participate in OSS: [Open Source Friday](https://opensourcefriday.com/)
 


### PR DESCRIPTION
Use https for the link to the open source survey. Avoids a 307 temporary redirect from the http to https site that currently happens when the link is clicked.

Also curious, is this organization still a thing or is it basically inactive/dead?